### PR TITLE
First release on GitHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,6 @@ language: c
 sudo: required
 dist: trusty
 
-env:
-  - TARGET=TOMU
-  - TARGET=MAPLE_MINI
-  - TARGET=BLUE_PILL
-  - TARGET=BLACK_PILL
-  - TARGET=ST_DONGLE
-  - ENFORCE_DEBUG_LOCK=1 TARGET=TOMU
-  - ENFORCE_DEBUG_LOCK=1 TARGET=MAPLE_MINI
-  - ENFORCE_DEBUG_LOCK=1 TARGET=BLUE_PILL
-  - ENFORCE_DEBUG_LOCK=1 TARGET=BLACK_PILL
-  - ENFORCE_DEBUG_LOCK=1 TARGET=ST_DONGLE
-
 addons:
   apt:
     packages:
@@ -21,15 +9,39 @@ addons:
       - openssl
 
 install:
-  - pip install asn1crypto --user
+  - pip install -r requirements.txt --user
   - sudo apt-add-repository -y ppa:team-gcc-arm-embedded/ppa
   - sudo apt-get update
   - sudo apt-get install -yy gcc-arm-embedded
 
 script:
-  - 'cd src'
-  - 'make TARGET=${TARGET} ENFORCE_DEBUG_LOCK=${ENFORCE_DEBUG_LOCK}'
-  - 'openssl ecparam -name prime256v1 -genkey -noout -outform der -out key.der'
-  - './inject_key.py --key key.der --ctr 1001'
-  - 'make clean distclean certclean'
-  - 'cd ..'
+  - |
+    set -e
+    mkdir artefacts
+    cd src
+    for ENFORCE_DEBUG_LOCK in 1 0 ; do
+      for EMPTY_ATTESTATION_CERT in 1 0 ; do
+        for TARGET in TOMU MAPLE_MINI BLUE_PILL BLACK_PILL ST_DONGLE ; do
+          make TARGET=${TARGET} EMPTY_ATTESTATION_CERT=${EMPTY_ATTESTATION_CERT} ENFORCE_DEBUG_LOCK=1 -j4
+          if [ "${EMPTY_ATTESTATION_CERT}" = 1 ] && [ "${ENFORCE_DEBUG_LOCK}" = 1 ] ; then
+            cp build/u2f.bin ../artefacts/u2f-${TARGET}.bin
+          fi
+          openssl ecparam -name prime256v1 -genkey -noout -outform der -out key.der
+          ./inject_key.py --key key.der --ctr 1001
+          make clean distclean certclean
+        done
+      done
+    done
+    cd ..
+
+deploy:
+  provider: releases
+  api_key:
+    secure: L44PBDcHxpeG/HN2rIkAycRfRV0uiuyHIAxk/VWGyg7K/COMDl4Nhwjg2a+G/vMtH3CIgih+dxlG6auVI1kFJNgpQOsuhn8obl+QrF1+Vw+8zHIHVPCVook30Ar5ovYjV9EXHpA6lHucFOrNFrJ4BeT6NdDYjWVq+c7+9jgjtk3Hdoz1OfYbVLhbNRVwv/SqC8tyo0EjOqG0Fe13XXYDjUzNsFYZOP9Xu0Y94O64i8akrfNzwC4xZHFLpH5MHoF6nd/LJXxixsJ2C2OYJAcjI6ju8qwjGPWvIbIV52xyrXyM/nswGo/B7s7w/B4o2cqciJEll8fRqtJKeE3AWPc5L3hWz1ii6fb+5dAbgW+triwpNjLnX5PzJSsH1no6+3eXW5GmQnvS3cf/ht22JUvy5XnSnn3AHgJTuvmKXJfvE48ZWDaM4US+4z+dLLNRtxEEsTDHRNa96inkLVI60ZHIwACw90z0avnr0rvUdEYsx56oksCN1HcRr0tK3x2iBpqzBPGOYcTBENMnhMevRie88hjidj/ePRem4yxHHswZKmEwu5kL65atjTWN6ZrQQOqO9BH0NiFXfk9gOoWwRLhF090qoMI8n8u5R5iXz8wAMbQzH7/rntoCoNUy9bxLcclmzrk9lsxlhDp46xYfOHH/R9BRcOFKAEymt6B1k41chkE=
+  file_glob: true
+  file: artefacts/*
+  skip_cleanup: true
+  draft: true
+  on:
+    repo: gl-sergei/u2f-token
+    tags: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+asn1crypto
+easyhid
+pyu2f

--- a/src/Makefile
+++ b/src/Makefile
@@ -50,6 +50,12 @@ ifeq ($(ENFORCE_DEBUG_LOCK),1)
 DEFS += -DENFORCE_DEBUG_LOCK
 endif
 
+ifeq ($(EMPTY_ATTESTATION_CERT),1)
+	GENCERT_CMD = cp empty-attestation-cert.c cert/certificates.c
+else
+	GENCERT_CMD = cd cert && ./gen.sh && cd ..
+endif
+
 CSRC = u2f.c usb-hid.c dbug.c u2f-hid.c u2f-apdu.c \
 	sha256.c neug.c random.c ec_p256r1.c bn.c jpc_p256r1.c \
 	call-ec_p256r1.c modp256r1.c mod.c hmac.c platform.c $(DRIVERS)
@@ -76,7 +82,7 @@ board.h:
 	ln -s $(BOARD) board.h
 
 cert/certificates.c:
-	cd cert && ./gen.sh && cd ..
+	$(GENCERT_CMD)
 
 sys.c: board.h
 u2f.c: board.h

--- a/src/cert/certtool
+++ b/src/cert/certtool
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# certtool - Initialize U2F-token with attestation certificate
+#
+# Copyright (C) 2019 Sergei Glushchenko
+# Author: Sergei Glushchenko <gl.sergei@gmail.com>
+#
+# This file is a part of U2F firmware for STM32 and EFM32HG
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# As additional permission under GNU GPL version 3 section 7, you may
+# distribute non-source form of the Program without the copy of the
+# GNU GPL normally required by section 4, provided you inform the
+# recipients of GNU GPL by a written offer.
+
+import easyhid
+import struct
+import secrets
+import argparse
+
+from asn1crypto.keys import ECPrivateKey
+
+FIDO_USAGE_PAGE = 0xF1D0
+U2F_USAGE = 1
+HID_RPT_SIZE = 64
+
+CMD_INIT = 0x06
+CMD_MSG = 0x03
+CMD_ERROR = 0x3f
+
+BROADCAST_CID = 0xffffffff
+
+def sendCommand(dev, channel, cmd, data):
+    msg = struct.pack('>IBH', channel, cmd | 0x80, len(data))
+    msg += data[:HID_RPT_SIZE - 7]
+    data = data[HID_RPT_SIZE - 7:]
+    dev.write(msg)
+    seq = 0
+    while data:
+        msg = struct.pack('>IB', channel, seq)
+        msg += data[:HID_RPT_SIZE - 5]
+        data = data[HID_RPT_SIZE - 5:]
+        dev.write(msg)
+        seq += 1
+
+def recvResponse(dev, channel):
+    data = dev.read()
+    ret_channel, cmd, len = struct.unpack(">IBH", data[:7])
+    if ret_channel != channel:
+        raise Exception("Wrong channel")
+    if cmd == CMD_ERROR | 0x80:
+        raise Exception("HID Error: {:d}".format(data[6]))
+    return data[7:7+len]
+
+def init(dev):
+    dev.open()
+    nonce = secrets.token_bytes(8)
+    sendCommand(dev, BROADCAST_CID, CMD_INIT, nonce)
+    data = recvResponse(dev, BROADCAST_CID)
+    if data[:8] != nonce:
+        raise Exception("Invalid nonce")
+    channel, = struct.unpack(">I", data[8:8+4])
+    return channel
+
+def put_cert(dev, cert, key):
+    channel = init(dev)
+    cla, ins, p1, p2 = 0, 0x40, 0, 0
+    Lc = len(cert) + len(key)
+    data = struct.pack('>BBBBBH', cla, ins, p1, p2, 0, Lc)
+    data += key + cert
+    sendCommand(dev, channel, CMD_MSG, data)
+    data = recvResponse(dev, channel)
+    if data != b'\x90\x00':
+        raise Exception("APDU Error: " + data.hex())
+
+def load_key(pk_der):
+    pk = ECPrivateKey.load(pk_der)
+    pk_hex = format(pk['private_key'].native, '064x')
+    return bytes.fromhex(pk_hex)
+
+def command_list(args):
+    e = easyhid.Enumeration()
+    devices = [ dev for dev in e.find() if dev.usage_page == FIDO_USAGE_PAGE ]
+
+    for dev in devices:
+        print(dev.description())
+
+def command_init(args):
+    e = easyhid.Enumeration()
+    devices = [ dev for dev in e.find() if dev.usage_page == FIDO_USAGE_PAGE ]
+
+    if len(devices) < 1:
+        raise Exception("No U2F devices found")
+
+    with open(args.certificate, "rb") as f:
+        cert = f.read()
+
+    with open(args.key, "rb") as f:
+        key = load_key(f.read())
+
+    for dev in devices:
+        print("Trying to initialize device {}".format(dev.description()))
+        try:
+            put_cert(dev, cert, key)
+            print('Success')
+        except Exception as e:
+            print(e)
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Initialize U2F-token with attestation certificate")
+    subparsers = parser.add_subparsers(help='available commands')
+    parser_list = subparsers.add_parser('list', help='list U2F devices')
+    parser_list.set_defaults(func=command_list)
+    parser_init = subparsers.add_parser('init', help='init U2F devices')
+    parser_init.add_argument("--certificate", default="attestation.der",
+                             help="attestation certificate in DER format")
+    parser_init.add_argument("--key", default="attestation_key.der",
+                             help="attestation certificate key in DER format")
+    parser_init.set_defaults(func=command_init)
+    args = parser.parse_args()
+
+    args.func(args)
+
+if __name__ == "__main__":
+    main()

--- a/src/cert/dump-der.py
+++ b/src/cert/dump-der.py
@@ -1,5 +1,39 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# dump-der.py - convert DER encoded certificate and EC key into C header
+#
+# Copyright (C) 2017-2019 Sergei Glushchenko
+# Author: Sergei Glushchenko <gl.sergei@gmail.com>
+#
+# This file is a part of U2F firmware for STM32 and EFM32HG
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# As additional permission under GNU GPL version 3 section 7, you may
+# distribute non-source form of the Program without the copy of the
+# GNU GPL normally required by section 4, provided you inform the
+# recipients of GNU GPL by a written offer.
+
 from __future__ import print_function
 from asn1crypto.keys import ECPrivateKey
+
+attestation_cert_def = '''const struct attestation_cert  __attribute__ ((section(".attestation.cert"))) attestation_cert = {
+  .der_len = ATTESTATION_DER_LEN,
+  .der = attestation_der,
+  .key = attestation_key
+};'''
 
 def pk_to_c_array(name, pk_der):
     # parse der format
@@ -34,3 +68,5 @@ with open("attestation.der", "rb") as f:
 
 with open("attestation_key.der", "rb") as f:
     print(pk_to_c_array("attestation_key", f.read()))
+
+print(attestation_cert_def)

--- a/src/efm32hg.ld
+++ b/src/efm32hg.ld
@@ -8,13 +8,13 @@ __process2_stack_size__  = 0x0100; /* blk                     */
 __process3_stack_size__  = 0x0200; /* usb-hid                 */
 __process4_stack_size__  = 0x0800; /* u2f-hid                 */
 __process5_stack_size__  = 0x0200; /* rng                     */
-__process6_stack_size__  = 0x0200; /* pbt / csn               */
+__process6_stack_size__  = 0x0100; /* pbt / csn               */
 
 MEMORY
 {
     flash  : org = 0x00004000, len = 46k
     ram : org = 0x20000000, len = 8k
-    flash1 : org = 0x00004000+0xb800, len = 2k
+    flash1 : org = 0x00004000+0xb400, len = 3k
 }
 
 __ram_start__           = ORIGIN(ram);
@@ -157,6 +157,9 @@ SECTIONS
 
     .flash_storage :
     {
+        . = ALIGN (1024);
+        _attestation_cert_base = .;
+        *(.attestation.cert);
         . = ALIGN (1024);
         _device_key_base = .;
         *(.device.key);

--- a/src/empty-attestation-cert.c
+++ b/src/empty-attestation-cert.c
@@ -1,0 +1,6 @@
+struct attestation_cert  __attribute__ ((section(".attestation.cert")))
+attestation_cert = {
+  .der_len = (uint32_t) -1,
+  .der = NULL,
+  .key = NULL
+};

--- a/src/platform.c
+++ b/src/platform.c
@@ -48,7 +48,7 @@ toboot_config = {
   .config = TOBOOT_CONFIG_FLAG_AUTORUN,
   .lock_entry = 0,
   .erase_mask_lo = 0x00000000,
-  .erase_mask_hi = 0xc0000000,
+  .erase_mask_hi = 0xe0000000,
   .reserved_hash = 0
 };
 

--- a/src/stm32f103.ld
+++ b/src/stm32f103.ld
@@ -14,7 +14,7 @@ MEMORY
 {
     flash0 : org = 0x08000000, len = 4k
     flash  : org = 0x08000000+0x1000, len = 58k
-    flash1 : org = 0x08000000+0xf800, len = 2k
+    flash1 : org = 0x08000000+0xf400, len = 3k
     ram : org = 0x20000000, len = 20k
 }
 
@@ -159,6 +159,9 @@ SECTIONS
 
     .flash_storage :
     {
+        . = ALIGN (1024);
+        _attestation_cert_base = .;
+        *(.attestation.cert);
         . = ALIGN (1024);
         _device_key_base = .;
         *(.device.key);

--- a/src/u2f-apdu.h
+++ b/src/u2f-apdu.h
@@ -6,7 +6,7 @@ void
 u2f_apdu_init (void);
 
 int
-u2f_apdu_command_do (uint8_t *apdu, uint8_t len,
+u2f_apdu_command_do (uint8_t *apdu, uint32_t len,
                      uint8_t *resp, uint32_t *resp_len);
 
 #endif

--- a/src/u2f-hid.c
+++ b/src/u2f-hid.c
@@ -1,7 +1,7 @@
 /*
  * u2f-hid.c - U2F HID protocol
  *
- * Copyright (C) 2017 Sergei Glushchenko
+ * Copyright (C) 2017-2019 Sergei Glushchenko
  * Author: Sergei Glushchenko <gl.sergei@gmail.com>
  *
  * This file is a part of U2F firmware for STM32
@@ -36,7 +36,7 @@
 #include "u2f-hid.h"
 #include "u2f-apdu.h"
 
-// Size of HID reports 
+// Size of HID reports
 
 #define HID_RPT_SIZE            64      // Default size of raw HID report
 
@@ -44,7 +44,7 @@
 
 #define CID_BROADCAST           0xffffffff // Broadcast channel id
 
-#define TYPE_MASK               0x80    // Frame type mask 
+#define TYPE_MASK               0x80    // Frame type mask
 #define TYPE_INIT               0x80    // Initial frame identifier
 #define TYPE_CONT               0x00    // Continuation frame identifier
 
@@ -81,8 +81,8 @@ typedef struct {
 #define FIDO_USAGE_U2FHID       0x01    // U2FHID usage for top-level collection
 #define FIDO_USAGE_DATA_IN      0x20    // Raw IN data report
 #define FIDO_USAGE_DATA_OUT     0x21    // Raw OUT data report
-        
-// General constants    
+
+// General constants
 
 #define U2FHID_IF_VERSION       2       // Current interface implementation version
 #define U2FHID_TRANS_TIMEOUT    3000    // Default message timeout in ms
@@ -99,7 +99,7 @@ typedef struct {
 
 #define U2FHID_VENDOR_FIRST (TYPE_INIT | 0x40)  // First vendor defined command
 #define U2FHID_VENDOR_LAST  (TYPE_INIT | 0x7f)  // Last vendor defined command
-    
+
 // U2FHID_INIT command defines
 
 #define INIT_NONCE_SIZE         8       // Size of channel initialization challenge
@@ -112,12 +112,12 @@ typedef struct {
 
 typedef struct {
   uint8_t nonce[INIT_NONCE_SIZE];       // Client application nonce
-  uint32_t cid;                         // Channel identifier  
+  uint32_t cid;                         // Channel identifier
   uint8_t versionInterface;             // Interface version
   uint8_t versionMajor;                 // Major version number
   uint8_t versionMinor;                 // Minor version number
   uint8_t versionBuild;                 // Build version number
-  uint8_t capFlags;                     // Capabilities flags  
+  uint8_t capFlags;                     // Capabilities flags
 } __attribute__ ((packed)) U2FHID_INIT_RESP;
 
 // U2FHID_SYNC command defines
@@ -152,7 +152,7 @@ extern uint8_t __process4_stack_base__[], __process4_stack_size__[];
 #define STACK_SIZE_U2F_HID ((uint32_t)__process4_stack_size__)
 
 #define MAX_MSGLEN 1024
-#define MAX_APDU_CMDLEN 160
+#define MAX_APDU_CMDLEN 416
 
 struct u2f_hid {
   uint32_t next_cid;

--- a/src/usb-hid.c
+++ b/src/usb-hid.c
@@ -1,7 +1,7 @@
 /*
  * usb-hid.c - HID device descriptors and communication
  *
- * Copyright (C) 2017 Sergei Glushchenko
+ * Copyright (C) 2017-2019 Sergei Glushchenko
  * Author: Sergei Glushchenko <gl.sergei@gmail.com>
  *
  * This file is a part of U2F firmware for STM32F103 and EFM32HG boards
@@ -55,7 +55,7 @@
 #define USB_DT_HID                      0x21
 #define USB_DT_REPORT                   0x22
 
-// Size of HID reports 
+// Size of HID reports
 
 #define HID_RPT_SIZE            64      // Default size of raw HID report
 
@@ -91,20 +91,20 @@ static const uint8_t hid_report_desc[] = {
 
 /* USB Device Descriptor */
 static const uint8_t u2f_device_desc[18] = {
-  18,   /* bLength */
-  DEVICE_DESCRIPTOR,                /* bDescriptorType */
-  0x10, 0x01,                        /* bcdUSB = 1.1 */
-  0x00,                                /* bDeviceClass (Unknown).          */
-  0x00,                                /* bDeviceSubClass.                 */
-  0x00,                                /* bDeviceProtocol.                 */
-  0x40,                                /* bMaxPacketSize.                  */
-  0x83, 0x04, /* idVendor  */
-  0xab, 0xcd, /* idProduct */
-  0x00, 0x01, /* bcdDevice  */
-  1,                                /* iManufacturer.                   */
-  2,                                /* iProduct.                        */
-  3,                                /* iSerialNumber.                   */
-  1                                /* bNumConfigurations.              */
+  18,                /* bLength */
+  DEVICE_DESCRIPTOR, /* bDescriptorType */
+  0x10, 0x01,        /* bcdUSB = 1.1 */
+  0x00,              /* bDeviceClass (Unknown). */
+  0x00,              /* bDeviceSubClass. */
+  0x00,              /* bDeviceProtocol. */
+  0x40,              /* bMaxPacketSize. */
+  0xd0, 0x16,        /* idVendor */
+  0x90, 0x0e,        /* idProduct */
+  0x00, 0x01,        /* bcdDevice */
+  1,                 /* iManufacturer. */
+  2,                 /* iProduct. */
+  3,                 /* iSerialNumber. */
+  1                  /* bNumConfigurations. */
 };
 
 #define FEATURE_BUS_POWERED        0x80
@@ -112,50 +112,50 @@ static const uint8_t u2f_device_desc[18] = {
 /* Configuration Descriptor tree for a HID.*/
 static const uint8_t u2f_config_desc[41] = {
   9,
-  CONFIG_DESCRIPTOR,                /* bDescriptorType: Configuration */
+  CONFIG_DESCRIPTOR,   /* bDescriptorType: Configuration */
   /* Configuration Descriptor.*/
-  41, 0x00,                        /* wTotalLength.                    */
-  0x01,                                /* bNumInterfaces.                  */
-  0x01,                                /* bConfigurationValue.             */
-  0,                                /* iConfiguration.                  */
-  FEATURE_BUS_POWERED,        /* bmAttributes.                    */
-  50,                                /* bMaxPower (100mA).               */
+  41, 0x00,            /* wTotalLength. */
+  0x01,                /* bNumInterfaces. */
+  0x01,                /* bConfigurationValue. */
+  0,                   /* iConfiguration. */
+  FEATURE_BUS_POWERED, /* bmAttributes. */
+  50,                  /* bMaxPower (100mA). */
 
   /* Interface Descriptor.*/
-  9,               /* bLength: Interface Descriptor size */
+  9,                    /* bLength: Interface Descriptor size */
   INTERFACE_DESCRIPTOR, /* bDescriptorType: Interface */
-  HID_INTERFACE,     /* bInterfaceNumber: Number of Interface */
-  0x00,     /* bAlternateSetting: Alternate setting */
-  0x02,     /* bNumEndpoints: Two endpoints used */
-  0x03,     /* bInterfaceClass: HID */
-  0x00,     /* bInterfaceSubClass: no boot */
-  0x00,     /* bInterfaceProtocol: 0=none */
-  0x04,     /* iInterface */
+  HID_INTERFACE,        /* bInterfaceNumber: Number of Interface */
+  0x00,                 /* bAlternateSetting: Alternate setting */
+  0x02,                 /* bNumEndpoints: Two endpoints used */
+  0x03,                 /* bInterfaceClass: HID */
+  0x00,                 /* bInterfaceSubClass: no boot */
+  0x00,                 /* bInterfaceProtocol: 0=none */
+  0x04,                 /* iInterface */
 
   /* HID Descriptor.*/
-  9,          /* bLength: HID Descriptor size */
-  0x21,         /* bDescriptorType: HID */
-  0x10, 0x01,   /* bcdHID: HID Class Spec release number */
-  0x00,         /* bCountryCode: Hardware target country */
-  0x01,         /* bNumDescriptors: Number of HID class descriptors to follow */
-  0x22,         /* bDescriptorType */
+  9,                       /* bLength: HID Descriptor size */
+  0x21,                    /* bDescriptorType: HID */
+  0x10, 0x01,              /* bcdHID: HID Class Spec release number */
+  0x00,                    /* bCountryCode: Hardware target country */
+  0x01,                    /* bNumDescriptors: Number of HID class descriptors to follow */
+  0x22,                    /* bDescriptorType */
   HID_REPORT_DESC_SIZE, 0, /* wItemLength: Total length of Report descriptor */
 
   /*Endpoint IN1 Descriptor*/
-  7,                            /* bLength: Endpoint Descriptor size */
+  7,                      /* bLength: Endpoint Descriptor size */
   ENDPOINT_DESCRIPTOR,    /* bDescriptorType: Endpoint */
-  0x81,       /* bEndpointAddress: (IN1) */
-  0x03,       /* bmAttributes: Interrupt */
-  0x40, 0x00,     /* wMaxPacketSize: 64 */
-  0x05,       /* bInterval (5ms) */
+  0x81,                   /* bEndpointAddress: (IN1) */
+  0x03,                   /* bmAttributes: Interrupt */
+  0x40, 0x00,             /* wMaxPacketSize: 64 */
+  0x05,                   /* bInterval (5ms) */
 
   /*Endpoint OUT1 Descriptor*/
-  7,                            /* bLength: Endpoint Descriptor size */
+  7,                      /* bLength: Endpoint Descriptor size */
   ENDPOINT_DESCRIPTOR,    /* bDescriptorType: Endpoint */
-  0x01,       /* bEndpointAddress: (OUT1) */
-  0x03,       /* bmAttributes: Interrupt */
-  0x40, 0x00,     /* wMaxPacketSize: 64 */
-  0x05,       /* bInterval (5ms) */
+  0x01,                   /* bEndpointAddress: (OUT1) */
+  0x03,                   /* bmAttributes: Interrupt */
+  0x40, 0x00,             /* wMaxPacketSize: 64 */
+  0x05,                   /* bInterval (5ms) */
 };
 
 
@@ -169,11 +169,10 @@ static const uint8_t usb_string0[4] = {
 };
 
 static const uint8_t usb_string1[] = {
-  9*2+2,                            /* bLength */
+  7*2+2,                            /* bLength */
   STRING_DESCRIPTOR,                /* bDescriptorType */
-  /* Manufacturer: "Gl.Sergei" */
-  'G', 0, 'l', 0, '.', 0, 'S', 0, 'e', 0, 'r', 0, 'g', 0, 'e', 0,
-  'i', 0,
+  /* Manufacturer: "unknown" */
+  'u', 0, 'n', 0, 'k', 0, 'n', 0, 'o', 0, 'w', 0, 'n', 0,
 };
 
 static const uint8_t usb_string2[] = {
@@ -195,9 +194,9 @@ static const uint8_t usb_string2[] = {
  * Serial Number string.
  */
 static const uint8_t usb_string3[28] = {
-  28,                                    /* bLength */
-  STRING_DESCRIPTOR,                    /* bDescriptorType */
-  '0', 0,  '.', 0,  '0', 0, '0', 0, /* Version number */
+  28,                               /* bLength */
+  STRING_DESCRIPTOR,                /* bDescriptorType */
+  '1', 0,  '.', 0,  '0', 0, '0', 0, /* Version number */
 };
 
 


### PR DESCRIPTION
- Add build option EMPTY_ATTESTATION_CERT to produce firmware without
  attestation certificate (needs to be initialized later)
- Add vendor command U2F_ATTESTATION_CERT (0x40) to initialize device
  with given attestation certificate
- Assign unique VID:PID