### PR TITLE
Use /usr/bin/env in bash script

### DIFF
--- a/src/cert/gen.sh
+++ b/src/cert/gen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Allows the script to be run in distributions like NixOS that don't follow the FHS