### PR TITLE
remove pyu2f from the requirements, as it's not used

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 asn1crypto
 easyhid
-pyu2f


### PR DESCRIPTION
Hi,

Working on the [Debian package](https://salsa.debian.org/debian/u2f-tomu/), I haven't found any mention of the `pyu2f` python library.

Thanks for this project.