### PR TITLE
Fix #45: Unable to initialize device with injected key

### DIFF
--- a/src/cert/dump-der.py
+++ b/src/cert/dump-der.py
@@ -31,10 +31,12 @@ from asn1crypto.keys import ECPrivateKey
 
 attestation_cert_def = '''
 struct attestation_cert  __attribute__ ((section(".attestation.cert"))) attestation_cert = {{
-  .der_len = ATTESTATION_DER_LEN,
-  .der = attestation_cert.pad,
-  .key = attestation_cert.pad + ATTESTATION_DER_LEN,
-  .pad = {{{}}}
+  .hdr = {{
+    .der_len = ATTESTATION_DER_LEN,
+    .der = attestation_cert.data,
+    .key = attestation_cert.data + ATTESTATION_DER_LEN,
+  }},
+  .data = {{{}}}
 }};'''
 
 def pk_to_hex_bytes(name, pk_der):

--- a/src/empty-attestation-cert.c
+++ b/src/empty-attestation-cert.c
@@ -1,6 +1,8 @@
 struct attestation_cert  __attribute__ ((section(".attestation.cert")))
 attestation_cert = {
-  .der_len = (uint32_t) -1,
-  .der = NULL,
-  .key = NULL
+  .hdr = {
+    .der_len = (uint32_t) -1,
+    .der = NULL,
+    .key = NULL
+  }
 };

--- a/src/u2f-apdu.c
+++ b/src/u2f-apdu.c
@@ -179,7 +179,10 @@ struct attestation_cert
   uint32_t der_len;
   const uint8_t *der;
   const uint8_t *key;
+  uint8_t pad[1024 - sizeof(uint32_t) - sizeof(uint8_t *) - sizeof(uint8_t *)];
 };
+
+_Static_assert(sizeof(struct attestation_cert) == 1024, "Wrong struct attestation_cert size");
 
 #include "cert/certificates.c"
 


### PR DESCRIPTION
1. Change inject_key.py to preserve this flash storage layout:
   - 1KiB attestation certificate and key
   - 1KiB device key
   - 1KiB auth counter

2. Change cert/gen.sh and friends to produce the same flash layout as above